### PR TITLE
force US-ASCII encoding for Ruby 2.0

### DIFF
--- a/lib/vpim/vcard.rb
+++ b/lib/vpim/vcard.rb
@@ -1,3 +1,5 @@
+# encoding: US-ASCII
+
 =begin
   Copyright (C) 2008 Sam Roberts
 


### PR DESCRIPTION
This error occurred on Ruby 2.0.

/vpim-rails/lib/vpim/vcard.rb:678: invalid multibyte escape: /^\xFE\xFF/ (SyntaxError)
invalid multibyte escape: /^\xFF\xFE/

Which uses UTF-8 encoding by default. This patch resolves the issue.
